### PR TITLE
Menu cleanup

### DIFF
--- a/code/modules/client/preference_setup/background/03_records.dm
+++ b/code/modules/client/preference_setup/background/03_records.dm
@@ -1,8 +1,8 @@
 /datum/preferences
-	var/public_record = ""
+//	var/public_record = ""		Commented out to slim down unused features -Breaks
 	var/med_record = ""
 	var/sec_record = ""
-	var/gen_record = ""
+//	var/gen_record = ""			Commented out to slim down unused features -Breaks
 	var/memory = ""
 	var/email_addr = ""
 	var/email_pass = ""
@@ -12,19 +12,19 @@
 	sort_order = 3
 
 /datum/category_item/player_setup_item/background/records/load_character(datum/pref_record_reader/R)
-	pref.public_record = R.read("public_record")
+//	pref.public_record = R.read("public_record")
 	pref.med_record = R.read("med_record")
 	pref.sec_record = R.read("sec_record")
-	pref.gen_record = R.read("gen_record")
+//	pref.gen_record = R.read("gen_record")
 	pref.memory = R.read("memory")
 	pref.email_addr = R.read("email_addr")
 	pref.email_pass = R.read("email_pass")
 
 /datum/category_item/player_setup_item/background/records/save_character(datum/pref_record_writer/W)
-	W.write("public_record", pref.public_record)
+//	W.write("public_record", pref.public_record)
 	W.write("med_record", pref.med_record)
 	W.write("sec_record", pref.sec_record)
-	W.write("gen_record", pref.gen_record)
+//	W.write("gen_record", pref.gen_record)
 	W.write("memory", pref.memory)
 	W.write("email_addr", pref.email_addr)
 	W.write("email_pass", pref.email_pass)
@@ -39,13 +39,14 @@
 	if (jobban_isbanned(user, "Records"))
 		. += "[SPAN_WARNING("You are banned from using character records.")]"
 	else
-		.+= UIBUTTON("set_public_record", TextPreview(pref.public_record, 40), "Public")
+//		.+= UIBUTTON("set_public_record", TextPreview(pref.public_record, 40), "Public")
 		.+= UIBUTTON("set_medical_records", TextPreview(pref.med_record, 40), "Medical")
-		.+= UIBUTTON("set_general_records", TextPreview(pref.gen_record, 40), "Employment")
+//		.+= UIBUTTON("set_general_records", TextPreview(pref.gen_record, 40), "Employment")
 		.+= UIBUTTON("set_security_records", TextPreview(pref.sec_record, 40), "Security")
 		.+= UIBUTTON("set_memory", TextPreview(pref.memory, 40), "Memory")
-
+/*		Commented out to slim down unused features -Breaks
 	. += "<br><b>Other</b>:"
+
 	var/set_addr_button = UIBUTTON("set_email_addr", pref.email_addr ? pref.email_addr : "(default)", "Email Address")
 	var/list/branches = pref.for_each_selected_branch(CALLBACK(src, .proc/allow_email_branch_check))
 	for (var/name in branches)
@@ -54,26 +55,26 @@
 
 	. += UIBUTTON("set_email_pass", pref.email_pass ? pref.email_pass : "(random)", "Email Password")
 	. = jointext(., "<br>")
-
+*/
 /datum/category_item/player_setup_item/background/records/OnTopic(var/href,var/list/href_list, var/mob/user)
-	if (href_list["set_public_record"])
+/*	if (href_list["set_public_record"])			Commented out to slim down unused features -Breaks
 		var/new_public = sanitize(input(user,"Enter general public record information here.",CHARACTER_PREFERENCE_INPUT_TITLE, html_decode(pref.public_record)) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)
 		if (!isnull(new_public) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
 			pref.public_record = new_public
 		return TOPIC_REFRESH
-
-	else if(href_list["set_medical_records"])
+*/
+	if(href_list["set_medical_records"])
 		var/new_medical = sanitize(input(user,"Enter medical information here.",CHARACTER_PREFERENCE_INPUT_TITLE, html_decode(pref.med_record)) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)
 		if(!isnull(new_medical) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
 			pref.med_record = new_medical
 		return TOPIC_REFRESH
-
+/*			Commented out to slim down unused features -Breaks
 	else if(href_list["set_general_records"])
 		var/new_general = sanitize(input(user,"Enter employment information here.",CHARACTER_PREFERENCE_INPUT_TITLE, html_decode(pref.gen_record)) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)
 		if(!isnull(new_general) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
 			pref.gen_record = new_general
 		return TOPIC_REFRESH
-
+*/
 	else if(href_list["set_security_records"])
 		var/sec_medical = sanitize(input(user,"Enter security information here.",CHARACTER_PREFERENCE_INPUT_TITLE, html_decode(pref.sec_record)) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)
 		if(!isnull(sec_medical) && !jobban_isbanned(user, "Records") && CanUseTopic(user))
@@ -85,7 +86,7 @@
 		if(!isnull(memes) && CanUseTopic(user))
 			pref.memory = memes
 		return TOPIC_REFRESH
-
+/*		Commented out to slim down unused features -Breaks
 	else if (href_list["set_email_pass"])
 		var/value = input(user, "Enter email password:", "Email Password", pref.email_pass) as text
 		if (isnull(value) || !CanUseTopic(user))
@@ -113,5 +114,5 @@
 			value = clean
 		pref.email_addr = value
 		return TOPIC_REFRESH
-
+*/
 	. =  ..()

--- a/code/modules/client/preference_setup/general/04_flavor.dm
+++ b/code/modules/client/preference_setup/general/04_flavor.dm
@@ -8,7 +8,7 @@
 
 /datum/category_item/player_setup_item/physical/flavor/load_character(datum/pref_record_reader/R)
 	pref.flavor_texts["general"] = R.read("flavor_texts_general")
-	pref.flavor_texts["head"] = R.read("flavor_texts_head")
+/*	pref.flavor_texts["head"] = R.read("flavor_texts_head")			Commented out to slim down unused features -Breaks
 	pref.flavor_texts["face"] = R.read("flavor_texts_face")
 	pref.flavor_texts["eyes"] = R.read("flavor_texts_eyes")
 	pref.flavor_texts["torso"] = R.read("flavor_texts_torso")
@@ -16,6 +16,7 @@
 	pref.flavor_texts["hands"] = R.read("flavor_texts_hands")
 	pref.flavor_texts["legs"] = R.read("flavor_texts_legs")
 	pref.flavor_texts["feet"] = R.read("flavor_texts_feet")
+*/
 
 	//Flavour text for robots.
 	pref.flavour_texts_robot["Default"] = R.read("flavour_texts_robot_Default")
@@ -24,7 +25,7 @@
 
 /datum/category_item/player_setup_item/physical/flavor/save_character(datum/pref_record_writer/W)
 	W.write("flavor_texts_general", pref.flavor_texts["general"])
-	W.write("flavor_texts_head", pref.flavor_texts["head"])
+/*	W.write("flavor_texts_head", pref.flavor_texts["head"])			Commented out to slim down unused features -Breaks
 	W.write("flavor_texts_face", pref.flavor_texts["face"])
 	W.write("flavor_texts_eyes", pref.flavor_texts["eyes"])
 	W.write("flavor_texts_torso", pref.flavor_texts["torso"])
@@ -32,6 +33,7 @@
 	W.write("flavor_texts_hands", pref.flavor_texts["hands"])
 	W.write("flavor_texts_legs", pref.flavor_texts["legs"])
 	W.write("flavor_texts_feet", pref.flavor_texts["feet"])
+*/
 
 	W.write("flavour_texts_robot_Default", pref.flavour_texts_robot["Default"])
 	for(var/module in SSrobots.all_module_names)
@@ -44,7 +46,7 @@
 /datum/category_item/player_setup_item/physical/flavor/content(var/mob/user)
 	. += "<b>Flavor:</b><br>"
 	. += "<a href='?src=\ref[src];flavor_text=open'>Set Flavor Text</a><br/>"
-	. += "<a href='?src=\ref[src];flavour_text_robot=open'>Set Robot Flavor Text</a><br/>"
+//	. += "<a href='?src=\ref[src];flavour_text_robot=open'>Set Robot Flavor Text</a><br/>"
 
 /datum/category_item/player_setup_item/physical/flavor/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(href_list["flavor_text"])
@@ -85,7 +87,7 @@
 	HTML += "<a href='?src=\ref[src];flavor_text=general'>General:</a> "
 	HTML += TextPreview(pref.flavor_texts["general"])
 	HTML += "<br>"
-	HTML += "<a href='?src=\ref[src];flavor_text=head'>Head:</a> "
+/*	HTML += "<a href='?src=\ref[src];flavor_text=head'>Head:</a> "		Commented out to slim down unused features -Breaks
 	HTML += TextPreview(pref.flavor_texts["head"])
 	HTML += "<br>"
 	HTML += "<a href='?src=\ref[src];flavor_text=face'>Face:</a> "
@@ -111,6 +113,7 @@
 	HTML += "<br>"
 	HTML += "<hr />"
 	HTML += "<tt>"
+*/
 	show_browser(user, HTML, "window=flavor_text;size=430x300")
 	return
 

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -186,12 +186,12 @@ var/list/_client_preferences_by_type
 	description = "Autohiss"
 	key = "AUTOHISS"
 	options = list(GLOB.PREF_OFF, GLOB.PREF_BASIC, GLOB.PREF_FULL)
-
+/*		Commented out to slim down unused features -Breaks
 /datum/client_preference/hardsuit_activation
 	description = "Hardsuit Module Activation Key"
 	key = "HARDSUIT_ACTIVATION"
 	options = list(GLOB.PREF_MIDDLE_CLICK, GLOB.PREF_CTRL_CLICK, GLOB.PREF_ALT_CLICK, GLOB.PREF_CTRL_SHIFT_CLICK)
-
+*/
 /datum/client_preference/holster_on_intent
 	description = "Draw gun based on intent"
 	key = "HOLSTER_ON_INTENT"

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -39,11 +39,12 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	sort_order = 7
 	category_item_type = /datum/category_item/player_setup_item/player_global
 
+/*	Commented out to slim down unused features -Breaks
 /datum/category_group/player_setup_category/law_pref
 	name = "Laws"
 	sort_order = 8
 	category_item_type = /datum/category_item/player_setup_item/law_pref
-
+*/
 
 /****************************
 * Category Collection Setup *


### PR DESCRIPTION
Commenting out various options in setup menu 
Unused and pointless features remaining is not good UI design, lets improve it a little.
If it did not get used on Bay due to being too detailed there is no chance it ever working as intended here, and a cleaner
aesthetic is more pleasing.
KISS.

DNM, until config on the repo is set, unable to actually test and debug with current setup.

Commented out options
General Record
Public Record
Custom email adress
Robot law preference
Flavor text per bodypart
Preferred hardsuit module activation key